### PR TITLE
handle answer ranking

### DIFF
--- a/answer_edit/ccm.answer_edit.js
+++ b/answer_edit/ccm.answer_edit.js
@@ -18,7 +18,7 @@
 
       "data": { "store": [ "ccm.store" ] },
 
-      // predefined strings
+      // predefined values
       "constants" : {
         "key_questions": "questions",   // key of store document containing question entries
         "qa_prefix": "qa_",             // will be prepended to question-answer pair indices to create element ID's
@@ -34,7 +34,8 @@
 
       // '$qa_id$' will be replaced with according values for each question
       "qa_html":
-`<div class="input-group row m-1">
+`
+<div class="input-group row m-1">
   <div class="input-group-prepend col-sm-0 p-1">
     <label for="$qa_id$_question" class="text-secondary">Question</label>
   </div>

--- a/answer_edit/ccm.answer_edit.js
+++ b/answer_edit/ccm.answer_edit.js
@@ -140,13 +140,16 @@
         renderQAPairs();
 
         // render save button
-        const saveButton = document.createElement( 'button' );
         const notificationSpan = document.createElement( 'span' );
+        const saveButton = document.createElement( 'button' );
         saveElem.appendChild( saveButton );
         saveElem.appendChild( notificationSpan );
+
+        notificationSpan.className = "alert alert-dismissible";
         saveButton.setAttribute( 'type', 'button' );
         saveButton.className = "btn btn-info";
         saveButton.innerText = 'Save';
+
         saveButton.addEventListener( 'click', async () => {
           let payload = {
             key : username,
@@ -163,11 +166,10 @@
           });
 
           await self.data.store.set( payload ).then( () => {
-            notificationSpan.innerHTML = 'Success';
-            notificationSpan.className = "alert alert-dismissible";
+            notificationSpan.innerText = 'Success';
             setTimeout( function () {
-              notificationSpan.innerHTML = ' ';
-            }, 1000 );
+              notificationSpan.innerText = '';
+            }, 1000 );  // message disappear after 1 second
           } );
         } );  // end saveButton.addEventListener()
 

--- a/answer_ranking/ccm.answer_ranking.js
+++ b/answer_ranking/ccm.answer_ranking.js
@@ -18,16 +18,51 @@
 
       'comp_sortable': [ 'ccm.component', '../sortable/ccm.sortable.js' ],
 
+      'user': [
+        'ccm.instance', 'https://ccmjs.github.io/akless-components/user/versions/ccm.user-8.3.1.js',
+        [ 'ccm.get', 'https://ccmjs.github.io/akless-components/user/resources/configs.js', 'hbrsinfkaul' ]
+      ],
+
+      // predefined values
+      'constants' : {
+        'key_questions': 'questions',   // key of store document containing question entries
+        'key_ans_prefix': 'answers_',   // question ID's will be appended to this to create the name of the document
+                                        // containing the question's answers
+        'num_answer': 5,                // number of answers to rank'question_html':
+        'question_html':                // default HTML for each question text element
+`
+<div class="input-group row m-1">
+  <div class="input-group-prepend col-sm-0 p-1">
+    <label for="q_$q_id$" class="text-secondary">Question</label>
+  </div>
+  <div class="col-sm-0">
+    <input type="text" readonly class="form-control-plaintext p-1 text-info" id="q_$q_id$" value="">
+  </div>
+</div>
+`,
+      },
+
       'html': {
         "main": {
           "id": "main",
           "inner": [
-            { "id": "question" },
-            { "id": "answers" },
+            { "id": "ranking" },
             { "id": "submit" }
           ]
+        },
+        "rank_entry": {
+          "class": "rank_entry",
+          "inner": [
+            { "id": "question" },
+            { "id": "answers" }
+          ]
         }
-      }
+      },
+
+      'css': [ 'ccm.load',
+        { url: '../lib/css/bootstrap.min.css', type: 'css' },
+        { url: '../lib/css/bootstrap.min.css', type: 'css', context: 'head' }
+      ],
     },
 
     Instance: function () {
@@ -44,35 +79,170 @@
 
       this.start = async () => {
         // get dataset for rendering
-        const dataset = await $.dataset( this.data );
+        const self = this;
+        let qaData = {};
+        let userData;
+
+        // login
+        let username;
+        self.user && await self.user.login().then ( () => {
+          username = self.user.data().user;
+        } ).catch( ( exception ) => console.log( 'login: ' + exception.error ) );
+
+        if ( !username ) {
+          self.element.innerHTML = '<div class="alert alert-info" role="alert">\n' +
+              '  Please login to continue!\n' +
+              '</div>';
+          return;
+        }
 
         // has logger instance? => log 'start' event
-        this.logger && this.logger.log( 'start', $.clone( dataset ) );
+        self.logger && self.logger.log( 'start' );
 
         // render main HTML structure
         $.setContent( this.element, $.html( this.html.main ) );
 
-        // contain list items
-        const question_elem = this.element.querySelector( '#question' );
-        const answers_elem = this.element.querySelector( '#answers' );
-        const submit_elem = this.element.querySelector( '#submit' );
+        // get page fragments
+        const rankingElem = this.element.querySelector( '#ranking' );
+        const submitElem = this.element.querySelector( '#submit' );
 
-        // render question
-        question_elem.innerHTML = dataset.question;
+        // load questions and answers from store
+        await self.data.store.get( self.constants.key_questions ).then(
+          questions => {
+            questions && questions.entries && Object.keys( questions.entries ).forEach( questionId => {
+              qaData[ questionId ] = {};
+              qaData[ questionId ][ 'question' ] = questions.entries[ questionId ];
+              self.data.store.get( self.constants.key_ans_prefix + questionId ).then( answers => {
+                if ( !answers ) {
+                  qaData[ questionId ][ 'answers' ] = {};
+                  return;
+                }
+                qaData[ questionId ][ 'answers' ] = answers;
+              },
+                reason => console.log( reason )               // read from data store failed
+              ).catch( err => console.log( err.message ) );   // unhandled exception
+            } );
+          },
+          reason => console.log( reason )               // read from data store failed
+        ).catch( err => console.log( err.message ) );   // unhandled exception
 
-        // render answers
-        const answer_comp = await this.comp_sortable.start({
-          root: answers_elem,
-          data: dataset.answers
-        });
+        // load user data
+        await self.data.store.get( username ).then( ud => {
+            userData = ud;
+          },
+          reason => console.log( reason )               // read from data store failed
+        ).catch( err => console.log( err.message ) );   // unhandled exception
 
-        // render submit button
-        const button = document.createElement( 'button' );
-        button.innerHTML = 'Submit';
-        button.addEventListener('click', () => {
-          console.log(answer_comp.getRanking());
-        });
-        submit_elem.appendChild(button);
+        // render question ranking entries
+        Object.keys( qaData ).forEach( async questionId => {
+          let selectedAns;
+          if ( !qaData[ questionId ][ 'answers' ] ) {
+            selectedAns = {}
+          } else {
+            selectedAns = getAnswers( userData, qaData[ questionId ][ 'answers' ] )
+          }
+          const docFrag = await renderAnswerRanking( questionId, selectedAns );
+          rankingElem.appendChild( docFrag );
+        } );
+
+        // render save button
+        const saveButton = document.createElement( 'button' );
+        saveButton.innerHTML = 'Save';
+        saveButton.className = 'btn btn-info';
+        saveButton.addEventListener( 'click', () => {
+          console.log( userData );
+        } );
+        submitElem.appendChild( saveButton );
+
+        function getAnswers( userData, allAnswers ) {
+          // if the number of ranked answers matches the specified, return these rankings
+          if ( Object.keys( userData[ 'ranking' ] ).length === self.constants.num_answer ) {
+            return userData[ 'ranking' ];
+          }
+
+          // else resample
+          const answers = {};
+          const ansByRankCount = {};
+          // first sort answers by rank count
+          for ( ansKey in allAnswers ) {
+            const numAnswers = Object.keys( answers ).length;
+            // if there are enough entries in 'answers', stop the loop
+            if ( numAnswers === self.constants.num_answer ) break;
+
+            // skip the user's own answers
+            if ( ansKey in  userData[ 'answers' ] ) continue;
+
+            // add to 'answers' if this answers is already ranked by the current user
+            if ( username in allAnswers[ ansKey ][ 'ranked_by' ] ) {
+              answers[ ansKey ] = numAnswers;
+              continue;
+            }
+
+            // else add to 'ansByRankCount'
+            const rankCount = Object.keys( allAnswers[ ansKey ][ 'ranked_by' ] ).length;
+            if ( rankCount in ansByRankCount ) {
+              ansByRankCount[ rankCount ].push( ansKey );
+            } else {
+              ansByRankCount[ rankCount ] = [ ansKey ];
+            }
+          }
+
+          // Fill 'answers' randomly, starting from ones with the least number of ranking
+          for ( rankCount in Object.keys( ansByRankCount ).sort() ) {
+            let ansCount = Object.keys( answers ).length;
+            // if there are enough entries in 'answers', stop the loop
+            if ( ansCount === self.constants.num_answer ) break;
+
+            // if there are not enough entries in 'answers' AND there are still answers with the current
+            // number of ranking, randomly add more entries to 'answers'
+            const answerKeys = ansByRankCount[ rankCount ];
+            while ( ansCount < self.constants.num_answer && answerKeys.length > 0 ) {
+              const randIndex = Math.floor( Math.random() * answerKeys.length );
+              const selectedAnsKey = answerKeys.splice( randIndex, 1 )[ 0 ];
+              answers[ selectedAnsKey ] = ansCount;
+              ansCount = Object.keys( answers ).length;
+            }
+          }
+          return answers;
+        }
+
+        async function renderAnswerRanking( questionId, selectedAnswers ) {
+          const qaRankingFragment = document.createDocumentFragment();
+          $.setContent( qaRankingFragment, $.html( self.html.rank_entry ) );
+
+          // render the question area
+          const questionText = qaData[ questionId ][ 'question' ];
+          const questionDiv = qaRankingFragment.querySelector( '#question' );
+          questionDiv.innerHTML = self.constants.question_html;
+          questionDiv.innerHTML = questionDiv.innerHTML.replace( /\$q_id\$/g, questionId );
+          const questionTextElem = questionDiv.querySelector( "#q_" + questionId );
+          questionTextElem.setAttribute( 'value', questionText );
+
+          // render the answer ranking area
+          const answersDiv = qaRankingFragment.querySelector( '#answers' );
+          const numAnswers = Object.keys( selectedAnswers ).length;
+          if ( numAnswers < self.constants.num_answer ) {
+            answersDiv.className = 'p-3 mb-2 bg-light text-dark';
+            answersDiv.innerText = 'can only find ' + numAnswers + ' answer(s) for this question, but we need '
+                                   + self.constants.num_answer + ' to rank';
+          } else {
+            // render answers
+            let answerEntries = [];
+            for ( ansId in selectedAnswers ) {
+              answerEntries[ selectedAnswers[ ansId ] ] = {
+                'id': ansId,
+                'content': qaData[ questionId ][ 'answers' ][ ansId ][ 'text' ]
+              };
+            }
+            console.log( answerEntries );
+            await self.comp_sortable.start( {
+              root: answersDiv,
+              data: { 'id': questionId + '_answers', 'items': answerEntries }
+            } );
+          }
+
+          return qaRankingFragment;
+        }  // end renderAnswerRanking()
       };
 
     }

--- a/answer_ranking/ccm.answer_ranking.js
+++ b/answer_ranking/ccm.answer_ranking.js
@@ -190,7 +190,7 @@
             if ( numAnswers === self.constants.num_answer ) break;
 
             // skip the user's own answers
-            if ( ansKey in  userData[ 'answers' ] ) continue;
+            if ( ansKey === userData[ 'answers' ][ questionId ][ 'hash' ] ) continue;
 
             // add to 'answers' if this answers is already ranked by the current user
             if ( username in allAnswers[ ansKey ][ 'ranked_by' ] ) {

--- a/answer_ranking/index.html
+++ b/answer_ranking/index.html
@@ -11,4 +11,4 @@
 </head>
 
 <script src="ccm.answer_ranking.js"></script>
-<ccm-answer_ranking key='["ccm.get","resources/configs.js","local"]'></ccm-answer_ranking>
+<ccm-answer_ranking key='["ccm.get","resources/configs.js","digiklausur"]'></ccm-answer_ranking>

--- a/answer_ranking/index.html
+++ b/answer_ranking/index.html
@@ -11,4 +11,4 @@
 </head>
 
 <script src="ccm.answer_ranking.js"></script>
-<ccm-answer_ranking key='["ccm.get","resources/configs.js","demo"]'></ccm-answer_ranking>
+<ccm-answer_ranking key='["ccm.get","resources/configs.js","local"]'></ccm-answer_ranking>

--- a/answer_ranking/resources/configs.js
+++ b/answer_ranking/resources/configs.js
@@ -4,19 +4,10 @@
  * @license The MIT License (MIT)
  */
 ccm.files[ 'configs.js' ] = {
-  "demo": {
-    "key": "demo",
+  "local": {
+    "key": "local",
     "data": {
-      "question": "how to foo bar?",
-      "answers": {
-        "id": "sortable_demo",
-        "items": [
-          { "id": "answer_1", "content": "Foo bar" },
-          { "id": "answer_2", "content": "FOo bar" },
-          { "id": "answer_3", "content": "FOO bar" },
-          { "id": "answer_4", "content": "FOO Bar" }
-        ]
-      }
+        "store": [ 'ccm.store', '../resources/question_answers_data.js' ]
     }
   }
 };

--- a/answer_ranking/resources/configs.js
+++ b/answer_ranking/resources/configs.js
@@ -4,6 +4,16 @@
  * @license The MIT License (MIT)
  */
 ccm.files[ 'configs.js' ] = {
+  "digiklausur": {
+      "key": "digiklausur",
+      "data": {
+          "store": [ "ccm.store", {
+              "name": "question_answers_sample",
+              "url": "https://digiklausur.ddns.net", "method": "POST"
+          } ]
+      }
+  },
+
   "localhost": {
       "key": "localhost",
       "data": {

--- a/answer_ranking/resources/configs.js
+++ b/answer_ranking/resources/configs.js
@@ -4,6 +4,16 @@
  * @license The MIT License (MIT)
  */
 ccm.files[ 'configs.js' ] = {
+  "localhost": {
+      "key": "localhost",
+      "data": {
+          "store": [ "ccm.store", {
+              "name": "question_answers_sample",
+              "url": "http://localhost:3000", "method": "POST"
+          } ]
+      }
+  },
+
   "local": {
     "key": "local",
     "data": {

--- a/resources/question_answers_data.js
+++ b/resources/question_answers_data.js
@@ -8,28 +8,44 @@ ccm.files[ 'question_answers_data.js' ] = {
     "questions": {
         "key" : "questions",
         "entries" : {
-            "9c7d5b046878838d" : {
-                "text" : "How are you?",
-                "last_modified" : "mnguy12s",
-                "answered_by" : []
-            },
-            "51ebe90aeed77259" : {
-                "text" : "what is robotics?",
-                "last_modified" : "mnguy12s",
-                "answered_by" : []
-            }
+            "9c7d5b046878838d" : "How are you?",
+            "51ebe90aeed77259" : "what is robotics?"
         }
     },
 
     "mnguy12s": {
         "answers": {
-            "9c7d5b046878838d": "es geht",
-            "51ebe90aeed77259": "I don't know"
+            "9c7d5b046878838d": {
+                "text": "es geht",
+                "hash": "d97363b4cb5ce806"
+            },
+            "51ebe90aeed77259": {
+                "text": "I don't know",
+                "hash": "807a4f302e7bbba1"
+            }
         },
         "ranking": {
-            "9c7d5b046878838d": [],
-            "51ebe90aeed77259": []
+            "9c7d5b046878838d": { },
+            "51ebe90aeed77259": { }
         }
+    },
+
+    "answers_9c7d5b046878838d": {
+        "d97363b4cb5ce806": { "text": "es geht", "ranked_by": {} },
+        "answer_hash_01": { "text": "es geht 1", "ranked_by": { 'username01': true } },
+        "answer_hash_02": { "text": "es geht 2", "ranked_by": { 'username02': true } },
+        "answer_hash_03": { "text": "es geht 3", "ranked_by": { 'username01': true } },
+        "answer_hash_04": { "text": "es geht 4", "ranked_by": {} },
+        "answer_hash_05": { "text": "es geht 5", "ranked_by": {} }
+    },
+
+    "answers_51ebe90aeed77259": {
+        "807a4f302e7bbba1": { "text": "I don't know", "ranked_by": { 'username01': true } },
+        "answer_hash_06": { "text": "I don't know 1", "ranked_by": { 'username02': true } },
+        "answer_hash_07": { "text": "I don't know 2", "ranked_by": { 'username02': true } },
+        "answer_hash_08": { "text": "I don't know 3", "ranked_by": {} },
+        "answer_hash_09": { "text": "I don't know 4", "ranked_by": {} },
+        "answer_hash_10": { "text": "I don't know 5", "ranked_by": {} }
     },
 
     "role": {

--- a/resources/question_answers_data.js
+++ b/resources/question_answers_data.js
@@ -31,21 +31,25 @@ ccm.files[ 'question_answers_data.js' ] = {
     },
 
     "answers_9c7d5b046878838d": {
-        "d97363b4cb5ce806": { "text": "es geht", "ranked_by": {} },
-        "answer_hash_01": { "text": "es geht 1", "ranked_by": { 'username01': true } },
-        "answer_hash_02": { "text": "es geht 2", "ranked_by": { 'username02': true } },
-        "answer_hash_03": { "text": "es geht 3", "ranked_by": { 'username01': true } },
-        "answer_hash_04": { "text": "es geht 4", "ranked_by": {} },
-        "answer_hash_05": { "text": "es geht 5", "ranked_by": {} }
+        "entries": {
+            "d97363b4cb5ce806": { "text": "es geht", "ranked_by": {} },
+            "answer_hash_01": { "text": "es geht 1", "ranked_by": { 'username01': true } },
+            "answer_hash_02": { "text": "es geht 2", "ranked_by": { 'username02': true } },
+            "answer_hash_03": { "text": "es geht 3", "ranked_by": { 'username01': true } },
+            "answer_hash_04": { "text": "es geht 4", "ranked_by": {} },
+            "answer_hash_05": { "text": "es geht 5", "ranked_by": {} }
+        }
     },
 
     "answers_51ebe90aeed77259": {
-        "807a4f302e7bbba1": { "text": "I don't know", "ranked_by": { 'username01': true } },
-        "answer_hash_06": { "text": "I don't know 1", "ranked_by": { 'username02': true } },
-        "answer_hash_07": { "text": "I don't know 2", "ranked_by": { 'username02': true } },
-        "answer_hash_08": { "text": "I don't know 3", "ranked_by": {} },
-        "answer_hash_09": { "text": "I don't know 4", "ranked_by": {} },
-        "answer_hash_10": { "text": "I don't know 5", "ranked_by": {} }
+        "entries": {
+            "807a4f302e7bbba1": { "text": "I don't know", "ranked_by": { 'username01': true } },
+            "answer_hash_06": { "text": "I don't know 1", "ranked_by": { 'username02': true } },
+            "answer_hash_07": { "text": "I don't know 2", "ranked_by": { 'username02': true } },
+            "answer_hash_08": { "text": "I don't know 3", "ranked_by": {} },
+            "answer_hash_09": { "text": "I don't know 4", "ranked_by": {} },
+            "answer_hash_10": { "text": "I don't know 5", "ranked_by": {} }
+        }
     },
 
     "role": {

--- a/sortable/ccm.sortable.js
+++ b/sortable/ccm.sortable.js
@@ -31,7 +31,7 @@
         ]
       },
 
-      'ranking': {}
+      'ranking': []
     },
 
     Instance: function () {
@@ -61,26 +61,27 @@
         const self = this; dataset = await $.dataset( this.data );
 
         // render list items
-        const ul_elem = document.createElement('ul');
-        ul_elem.classList.add('list-group');
+        const ul_elem = document.createElement( 'ul' );
+        ul_elem.classList.add( 'list-group' );
         ul_elem.id = dataset.id;
-        items_elem.appendChild(ul_elem);
+        items_elem.appendChild( ul_elem );
         dataset.items && dataset.items.forEach( renderListItem );
-        Sortable.create(ul_elem, {
-          onSort: function (event) {
-            let tmp = self.ranking[event.newIndex];
-            self.ranking[event.newIndex] = self.ranking[event.oldIndex];
-            self.ranking[event.oldIndex] = tmp;
+        Sortable.create( ul_elem, {
+          onSort: function ( event ) {
+            // remove entry from array at old index
+            const draggedItem = self.ranking.splice( event.oldIndex, 1 )[ 0 ];
+            // insert entry at new index
+            self.ranking.splice( event.newIndex, 0, draggedItem );
           }
-        });
+        } );
 
-        function renderListItem( item_data, i ) {
-          const li_elem = document.createElement('li');
+        function renderListItem( item_data ) {
+          const li_elem = document.createElement( 'li' );
           li_elem.innerHTML = item_data.content;
           li_elem.id = item_data.id;
-          li_elem.classList.add('list-group-item','ui-state-default');
-          ul_elem.appendChild(li_elem);
-          self.ranking[i] = li_elem.id;
+          li_elem.classList.add( 'list-group-item','ui-state-default' );
+          ul_elem.appendChild( li_elem );
+          self.ranking.push( li_elem.id );
         }
       };
 


### PR DESCRIPTION
- load questions and answers from the store as created by `question_edit` and `answer_edit`
- sample random answers, ensure least ranked answers to be picked first
- fix an issue with `ccm.sortable.js` where dragging an item more than 2 rows would break the ranking
- update demo data
- depends on PR digiklausur/ccm_data_server#12
- resolves #2 